### PR TITLE
Update Infura api url

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 const createInfuraProvider = require('eth-json-rpc-infura/src/createProvider')
 const Ethjs = require('ethjs')
 
-const provider = createInfuraProvider({ network: 'mainnet' })
+const provider = createInfuraProvider({ network: 'mainnet', projectId: 'abcdef1234567890abcdef1234567890' })
 const eth = new Ethjs(provider)
 ```
 
@@ -19,5 +19,5 @@ const createInfuraMiddleware = require('eth-json-rpc-infura')
 const RpcEngine = require('json-rpc-engine')
 
 const engine = new RpcEngine()
-engine.push(createInfuraMiddleware({ network: 'ropsten' }))
+engine.push(createInfuraMiddleware({ network: 'goerli', projectId: 'abcdef1234567890abcdef1234567890'}))
 ```

--- a/src/index.js
+++ b/src/index.js
@@ -102,13 +102,13 @@ async function performFetch(network, req, res, source, projectId){
   res.error = data.error
 }
 
-function fetchConfigFromReq({ network, req, source }) {
+function fetchConfigFromReq({ network, req, source, projectId }) {
   const requestOrigin = req.origin || 'internal'
   const cleanReq = normalizeReq(req)
   const { method, params } = cleanReq
 
   const fetchParams = {}
-  let fetchUrl = `https://${network}.infura.io/v3/${apiKey}`
+  let fetchUrl = `https://${network}.infura.io/v3/${projectId}`
   const isPostMethod = POST_METHODS.includes(method)
   if (isPostMethod) {
     fetchParams.method = 'POST'

--- a/src/index.js
+++ b/src/index.js
@@ -20,6 +20,7 @@ function createInfuraMiddleware(opts = {}) {
   const network = opts.network || 'mainnet'
   const maxAttempts = opts.maxAttempts || 5
   const source = opts.source
+  const projectId = opts.projectId
 
   // validate options
   if (!maxAttempts) throw new Error(`Invalid value for 'maxAttempts': "${maxAttempts}" (${typeof maxAttempts})`)
@@ -29,7 +30,7 @@ function createInfuraMiddleware(opts = {}) {
     for (let attempt = 1; attempt <= maxAttempts; attempt++) {
       try {
         // attempt request
-        await performFetch(network, req, res, source)
+        await performFetch(network, req, res, source, projectId)
         // request was successful
         break
       } catch (err) {
@@ -65,8 +66,8 @@ function isRetriableError(err) {
   return RETRIABLE_ERRORS.some(phrase => errMessage.includes(phrase))
 }
 
-async function performFetch(network, req, res, source){
-  const { fetchUrl, fetchParams } = fetchConfigFromReq({ network, req, source })
+async function performFetch(network, req, res, source, projectId){
+  const { fetchUrl, fetchParams } = fetchConfigFromReq({ network, req, source, projectId })
   const response = await fetch(fetchUrl, fetchParams)
   const rawData = await response.text()
   // handle errors
@@ -107,7 +108,7 @@ function fetchConfigFromReq({ network, req, source }) {
   const { method, params } = cleanReq
 
   const fetchParams = {}
-  let fetchUrl = `https://api.infura.io/v1/jsonrpc/${network}`
+  let fetchUrl = `https://${network}.infura.io/v3/${apiKey}`
   const isPostMethod = POST_METHODS.includes(method)
   if (isPostMethod) {
     fetchParams.method = 'POST'

--- a/src/index.js
+++ b/src/index.js
@@ -103,6 +103,7 @@ async function performFetch(network, req, res, source, projectId){
 }
 
 function fetchConfigFromReq({ network, req, source, projectId }) {
+  if (!projectId) throw new Error('eth-json-rpc-infura - must provide projectId in options')
   const requestOrigin = req.origin || 'internal'
   const cleanReq = normalizeReq(req)
   const { method, params } = cleanReq


### PR DESCRIPTION
Infura is going to be deprecating the v1 api on March 27. In anticipation for that, all access urls need to be updated to the v3 URL. 

This updates the codebase to use the v3 format. However, it requires new parameter to be passed into the `opts` object that creates the provider. Someone instantiating this provider needs to provide the `projectId`. As an addendum to this PR, it would be good to provide a default key issued to Metamask if one is not included with the provider instantiation.