### PR TITLE
Update minimum `node-fetch` version

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "eth-json-rpc-middleware": "^6.0.0",
     "eth-rpc-errors": "^3.0.0",
     "json-rpc-engine": "^5.3.0",
-    "node-fetch": "^2.6.0"
+    "node-fetch": "^2.6.1"
   },
   "devDependencies": {
     "@metamask/eslint-config": "^3.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1199,7 +1199,7 @@ nice-try@^1.0.4:
   resolved "https://registry.yarnpkg.com/nice-try/-/nice-try-1.0.5.tgz#a3378a7696ce7d223e88fc9b764bd7ef1089e366"
   integrity sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ==
 
-node-fetch@^2.6.0, node-fetch@^2.6.1:
+node-fetch@^2.6.1:
   version "2.6.1"
   resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.6.1.tgz#045bd323631f76ed2e2b55573394416b639a0052"
   integrity sha512-V4aYg89jEoVRxRb2fJdAg8FHvI7cEyYdVAh94HH0UIK8oJxUfkjlDQN9RbMx+bEjP7+ggMiFRprSti032Oipxw==


### PR DESCRIPTION
v2.6.1 of `node-fetch` included a security fix. We were already using v2.6.1 in the lockfile, but we may as well make it a hard requirement.