### PR TITLE
Correct usage examples in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ ethQuery.blockNumber((err, result) => {
   } else {
     // use the result in some way
   }
-})
+});
 ```
 
 ### Creating `json-rpc-engine` middleware
@@ -50,7 +50,7 @@ const result = await engine.handle({
   id: 1,
   jsonrpc: '2.0',
   method: 'eth_blockNumber',
-  params: []
+  params: [],
 });
 ```
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # eth-json-rpc-infura
 
 [`json-rpc-engine`](https://github.com/MetaMask/json-rpc-engine) middleware for
-infura's REST endpoints.
+Infura's REST endpoints.
 
 ## Installation
 
@@ -16,29 +16,42 @@ or
 ### Creating a provider
 
 ```js
-const createInfuraProvider = require('eth-json-rpc-infura/src/createProvider');
-const Eth = require('ethjs');
+const { createInfuraProvider } = require('@metamask/eth-json-rpc-infura');
+const EthQuery = require('eth-query');
 
 const provider = createInfuraProvider({
   network: 'ropsten',
   projectId: 'abcdef1234567890',
 });
-const eth = new Eth(provider);
+const ethQuery = new EthQuery(provider);
+ethQuery.blockNumber((err, result) => {
+  if (err) {
+    // do something with the error
+  } else {
+    // use the result in some way
+  }
+})
 ```
 
-### Creating middleware
+### Creating `json-rpc-engine` middleware
 
 ```js
-const createInfuraMiddleware = require('eth-json-rpc-infura');
-const RpcEngine = require('json-rpc-engine');
+const { createInfuraMiddleware } = require('@metamask/eth-json-rpc-infura');
+const JsonRpcEngine = require('json-rpc-engine');
 
-const engine = new RpcEngine();
+const engine = new JsonRpcEngine();
 engine.push(
   createInfuraMiddleware({
     network: 'ropsten',
     projectId: 'abcdef1234567890',
   }),
 );
+const result = await engine.handle({
+  id: 1,
+  jsonrpc: '2.0',
+  method: 'eth_blockNumber',
+  params: []
+});
 ```
 
 ## Contributing


### PR DESCRIPTION
After the package name was updated and the exports were consolidated,
the README was never updated to reflect the new changes. This takes care
of that and slightly extends the examples so that they are more
complete. We also use `eth-query` instead of `ethjs` as that's what we
use internally at MetaMask.