### PR TITLE
Add sepolia to InfuraJsonRpcSupportedNetwork

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -16,6 +16,7 @@ export type InfuraJsonRpcSupportedNetwork =
   | 'rinkeby'
   | 'kovan'
   | 'goerli'
+  | 'sepolia'
   | 'eth2-beacon-mainnet'
   | 'filecoin'
   | 'polygon-mainnet'


### PR DESCRIPTION
This PR adds the support to Sepolia network on type InfuraJsonRpcSupportedNetwork, according to the [supported Infura network list](https://docs.infura.io/infura/networks/ethereum/how-to/choose-a-network).

This is also needed for [#16580](https://github.com/metamask/metamask-extension/issues/16580)

