### PR TITLE
deps: @metamask/utils@^3.6.0->^4.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
   },
   "dependencies": {
     "@metamask/eth-json-rpc-provider": "^1.0.0",
-    "@metamask/utils": "^3.6.0",
+    "@metamask/utils": "^4.0.0",
     "eth-rpc-errors": "^4.0.3",
     "json-rpc-engine": "^6.1.0",
     "node-fetch": "^2.6.7"

--- a/yarn.lock
+++ b/yarn.lock
@@ -629,10 +629,10 @@
   resolved "https://registry.yarnpkg.com/@metamask/safe-event-emitter/-/safe-event-emitter-2.0.0.tgz#af577b477c683fad17c619a78208cede06f9605c"
   integrity sha512-/kSXhY692qiV1MXu6EeOZvg5nECLclxNXcKCxJ3cXQgYuRymRHpdx/t7JXfsK+JLjwA1e1c1/SBrlQYpusC29Q==
 
-"@metamask/utils@^3.6.0":
-  version "3.6.0"
-  resolved "https://registry.yarnpkg.com/@metamask/utils/-/utils-3.6.0.tgz#b218b969a05ca7a8093b5d1670f6625061de707d"
-  integrity sha512-9cIRrfkWvHblSiNDVXsjivqa9Ak0RYo/1H6tqTqTbAx+oBK2Sva0lWDHxGchOqA7bySGUJKAWSNJvH6gdHZ0gQ==
+"@metamask/utils@^4.0.0":
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/@metamask/utils/-/utils-4.0.0.tgz#9fe302aba111c68168ab088ea2a069247fb2380d"
+  integrity sha512-BqLx6UWkzTn33ICbzssC4gI7N++dPJAEy/oXJD8LFY02MP0ORwulXMdHT9fQO1i8r/oi0wSMCPxAaT/IYiy8YA==
   dependencies:
     "@types/debug" "^4.1.7"
     debug "^4.3.4"


### PR DESCRIPTION
Further update will have to wait until after bumping `engines.node` to min 16 due to subdependency `@noble/hashes` in `5.0.0`+.

[`@metamask/utils@4.0.0` changelog](https://github.com/MetaMask/utils/releases/tag/v4.0.0)