### PR TITLE
ci: run on ubuntu-latest(22.04) instead of ubuntu-20.04

### DIFF
--- a/.github/workflows/lint-test.yml
+++ b/.github/workflows/lint-test.yml
@@ -8,7 +8,7 @@ on:
 jobs:
   build-lint-test:
     name: Build, Lint, and Test
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     strategy:
       matrix:
         node-version: [16.x, 18.x, 20.x]
@@ -51,7 +51,7 @@ jobs:
           fi
   all-jobs-pass:
     name: All jobs pass
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     needs:
       - build-lint-test
     steps:


### PR DESCRIPTION
GH recommends `ubuntu-latest` (current: 22.04 LTS) as default.