### PR TITLE
Remove Aurora support

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -24,8 +24,6 @@ export type InfuraJsonRpcSupportedNetwork =
   | 'optimism-goerli'
   | 'arbitrum-mainnet'
   | 'arbitrum-goerli'
-  | 'aurora-mainnet'
-  | 'aurora-testnet'
   | 'avalanche-mainnet'
   | 'avalanche-fuji'
   | 'celo-mainnet'


### PR DESCRIPTION
Infura is deprecating support for Aurora; this PR removes types for Aurora testnet and mainnet