### PR TITLE
feat: add Linea Sepolia to infura supported networks

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -35,4 +35,5 @@ export type InfuraJsonRpcSupportedNetwork =
   | 'starknet-mainnet'
   | 'starknet-goerli'
   | 'linea-goerli'
+  | 'linea-sepolia'
   | 'linea-mainnet';


### PR DESCRIPTION
A new Linea Sepolia network will be added to MM soon. This PR adds the  Linea Sepolia network to infura supported networks list.