### PR TITLE
Treat non-standard JSON-RPC errors as standard

### DIFF
--- a/src/create-infura-middleware.ts
+++ b/src/create-infura-middleware.ts
@@ -3,7 +3,6 @@ import { createAsyncMiddleware } from '@metamask/json-rpc-engine';
 import type { JsonRpcError } from '@metamask/rpc-errors';
 import { rpcErrors } from '@metamask/rpc-errors';
 import {
-  isJsonRpcFailure,
   type Json,
   type JsonRpcParams,
   type PendingJsonRpcResponse,
@@ -149,7 +148,7 @@ function createInfuraMiddlewareWithRpcService({
       // Discard the `id` and `jsonrpc` fields in the response body
       // (the JSON-RPC engine will fill those in)
 
-      if (isJsonRpcFailure(jsonRpcResponse)) {
+      if ('error' in jsonRpcResponse) {
         res.error = jsonRpcResponse.error;
       } else {
         res.result = jsonRpcResponse.result;


### PR DESCRIPTION
The [JSON-RPC specification](https://www.jsonrpc.org/specification) says that a JSON-RPC-compliant server must return a response with either a `result` or an `error` field, and if an `error` field is present, then it must be an object with the following fields: `code`, `message`, and `data`. The `isJsonRpcError` from `@metamask/utils` (via the [`JsonRpcError` type][2]) not only checks for the three aforementioned properties, but also allows an additional, optional `stack` property to be present. However, it does not allow any other properties beyond the four declared.

This is a problem because the new implementation of this middleware makes use of this function to know how to handle errors, and as a result, non-standard error responses are being treated as successful responses (and the errors themselves are being discarded). This is particularly noticeable when using Ganache as a local RPC server, because it produces such non-standard error responses, such as when a transaction fails.

To correct this bug, this commit brings the error-handling code in the middleware closer to the original implementation, and updates the tests to ensure that Ganache errors are treated correctly.

[1]: https://www.jsonrpc.org/specification
[2]: https://github.com/MetaMask/utils/blob/55b22a77e75641c4c8b05eec73982084ac9e7332/src/json.ts#L301

---

This is a similar fix as https://github.com/MetaMask/eth-json-rpc-middleware/pull/367. I have tested this in `network-controller` and can confirm that this has the same effect.