### PR TITLE
chore: Simplify RPC service type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 ### Changed
+- Simplify `rpcService` parameter type of `createInfuraMiddleware` ([#127](https://github.com/MetaMask/eth-json-rpc-infura/pull/127))
 - Bump `@metamask/eth-json-rpc-provider` from `^4.1.7` to `^5.0.0` ([#126](https://github.com/MetaMask/eth-json-rpc-infura/pull/126))
 - Bump `@metamask/json-rpc-engine` from `^10.0.2` to `^10.1.0` ([#126](https://github.com/MetaMask/eth-json-rpc-infura/pull/126))
 

--- a/src/create-infura-middleware.test.ts
+++ b/src/create-infura-middleware.test.ts
@@ -2,7 +2,7 @@ import { JsonRpcEngine } from '@metamask/json-rpc-engine';
 import type { Json, JsonRpcParams, JsonRpcRequest } from '@metamask/utils';
 
 import { createInfuraMiddleware } from '.';
-import type { AbstractRpcService } from './types';
+import type { AbstractRpcServiceLike } from './types';
 
 describe('createInfuraMiddleware (given an RPC service)', () => {
   it('calls the RPC service with the correct request headers and body when no `source` option given', async () => {
@@ -325,10 +325,8 @@ describe('createInfuraMiddleware (given an RPC endpoint)', () => {
  * Constructs a fake RPC service for use as a failover in tests.
  * @returns The fake failover service.
  */
-function buildRpcService(): AbstractRpcService {
+function buildRpcService(): AbstractRpcServiceLike {
   return {
-    endpointUrl: new URL('https://metamask.test'),
-
     async request<Params extends JsonRpcParams, Result extends Json>(
       jsonRpcRequest: JsonRpcRequest<Params>,
       _fetchOptions?: RequestInit,
@@ -337,27 +335,6 @@ function buildRpcService(): AbstractRpcService {
         id: jsonRpcRequest.id,
         jsonrpc: jsonRpcRequest.jsonrpc,
         result: 'ok' as Result,
-      };
-    },
-    onRetry() {
-      return {
-        dispose() {
-          // do nothing
-        },
-      };
-    },
-    onBreak() {
-      return {
-        dispose() {
-          // do nothing
-        },
-      };
-    },
-    onDegraded() {
-      return {
-        dispose() {
-          // do nothing
-        },
       };
     },
   };

--- a/src/create-infura-middleware.ts
+++ b/src/create-infura-middleware.ts
@@ -11,7 +11,7 @@ import {
 import { fetchConfigFromReq } from './fetch-config-from-req';
 import { projectLogger, createModuleLogger } from './logging-utils';
 import type {
-  AbstractRpcService,
+  AbstractRpcServiceLike,
   ExtendedJsonRpcRequest,
   InfuraJsonRpcSupportedNetwork,
   RequestHeaders,
@@ -56,7 +56,7 @@ const RETRIABLE_ERRORS = [
  * @returns The fetch middleware.
  */
 export function createInfuraMiddleware(args: {
-  rpcService: AbstractRpcService;
+  rpcService: AbstractRpcServiceLike;
   options?: {
     source?: string;
     headers?: Headers;
@@ -89,7 +89,7 @@ export function createInfuraMiddleware(
 export function createInfuraMiddleware(
   args:
     | {
-        rpcService: AbstractRpcService;
+        rpcService: AbstractRpcServiceLike;
         options?: {
           source?: string;
           headers?: Headers;
@@ -118,7 +118,7 @@ function createInfuraMiddlewareWithRpcService({
   rpcService,
   options = {},
 }: {
-  rpcService: AbstractRpcService;
+  rpcService: AbstractRpcServiceLike;
   options?: {
     source?: string;
     headers?: Headers;

--- a/src/types.test-d.ts
+++ b/src/types.test-d.ts
@@ -1,9 +1,10 @@
-import type { AbstractRpcService as NetworkControllerAbstractRpcService } from '@metamask/network-controller';
+import type { AbstractRpcService } from '@metamask/network-controller';
 import { expectAssignable } from 'tsd';
 
-import type { AbstractRpcService as LocalAbstractRpcService } from './types';
+import type { AbstractRpcServiceLike } from './types';
 
-// Confirm that the AbstractRpcService in this repo is compatible with the same
-// one in `@metamask/network-controller` (from where it was copied)
-declare const rpcService: LocalAbstractRpcService;
-expectAssignable<NetworkControllerAbstractRpcService>(rpcService);
+// Confirm that the `AbstractRpcServiceLike` type in this repo is compatible
+// with the type of the `request` method from `AbstractRpcService` in
+// `@metamask/network-controller` (from where it was copied).
+declare const networkControllerRpcService: AbstractRpcService;
+expectAssignable<AbstractRpcServiceLike>(networkControllerRpcService);

--- a/src/types.ts
+++ b/src/types.ts
@@ -46,63 +46,19 @@ export type InfuraJsonRpcSupportedNetwork =
   | 'sei-testnet';
 
 /**
- * The interface for a service class responsible for making a request to an RPC
- * endpoint.
+ * A copy of the `AbstractRpcService` type in metamask/network-controller`, but
+ * keeping only the `request` method.
+ *
+ * We cannot get `AbstractRpcService` directly from
+ * `@metamask/network-controller` because relying on this package would create a
+ * circular dependency.
+ *
+ * This type should be accurate as of `@metamask/network-controller` 24.x and
+ * `@metamask/utils` 11.x.
  */
-export type AbstractRpcService = {
-  /**
-   * The URL of the RPC endpoint.
-   */
-  endpointUrl: URL;
-
-  /**
-   * Listens for when the RPC service retries the request.
-   * @param listener - The callback to be called when the retry occurs.
-   * @returns A disposable.
-   */
-  onRetry: (
-    listener: (
-      data: ({ error: Error } | { value: unknown }) & {
-        delay: number;
-        attempt: number;
-        endpointUrl: string;
-      },
-    ) => void,
-  ) => {
-    dispose(): void;
-  };
-
-  /**
-   * Listens for when the RPC service retries the request too many times in a
-   * row.
-   * @param listener - The callback to be called when the circuit is broken.
-   * @returns A disposable.
-   */
-  onBreak: (
-    listener: (
-      data: ({ error: Error } | { value: unknown } | { isolated: true }) & {
-        endpointUrl: string;
-      },
-    ) => void,
-  ) => {
-    dispose(): void;
-  };
-
-  /**
-   * Listens for when the policy underlying this RPC service detects a slow
-   * request.
-   * @param listener - The callback to be called when the request is slow.
-   * @returns A disposable.
-   */
-  onDegraded: (listener: (data: { endpointUrl: string }) => void) => {
-    dispose(): void;
-  };
-
-  /**
-   * Makes a request to the RPC endpoint.
-   */
-  request<Params extends JsonRpcParams, Result extends Json>(
+export type AbstractRpcServiceLike = {
+  request: <Params extends JsonRpcParams, Result extends Json>(
     jsonRpcRequest: JsonRpcRequest<Params>,
     fetchOptions?: RequestInit,
-  ): Promise<JsonRpcResponse<Result | null>>;
+  ) => Promise<JsonRpcResponse<Result | null>>;
 };


### PR DESCRIPTION
This applies the changes made in https://github.com/MetaMask/eth-json-rpc-middleware/pull/407 to this package. This type simplification reduces the chances that we'll need to update this again in the future.